### PR TITLE
Remove "typename" keywords in Definitions.h for GCC 4.4.x toolchain.

### DIFF
--- a/include/Definitions.h
+++ b/include/Definitions.h
@@ -30,14 +30,14 @@
 
 using namespace std;
 
-typedef typename itk::Image<short, 3>           ImageType;
-typedef typename ImageType::Pointer             ImagePointerType;
-typedef typename itk::Point<double,3>           PhysicalPointType;  
-typedef typename ImageType::IndexType 	        VoxelPointType;
+typedef itk::Image<short, 3>           ImageType;
+typedef ImageType::Pointer             ImagePointerType;
+typedef itk::Point<double,3>           PhysicalPointType;
+typedef ImageType::IndexType 	        VoxelPointType;
 typedef itk::ImageFileReader< ImageType >       ImageReaderType;
 typedef itk::ImageMomentsCalculator<ImageType>  CalculatorType;
-typedef typename ImageType::SizeType                     SizeType;
-typedef typename ImageType::RegionType 		              RegionType;
+typedef ImageType::SizeType                     SizeType;
+typedef ImageType::RegionType 		              RegionType;
 typedef ImageType::SpacingType                                SpacingType;
 typedef itk::RegionOfInterestImageFilter<ImageType,ImageType> FilterType;
 


### PR DESCRIPTION
Redhat/CentOS 6.x use gcc 4.4.x as its default compiler, which complains the 'typename' is outside of a template. It is safe to remove them.